### PR TITLE
Fix signed ints in `osmosis-std` package

### DIFF
--- a/packages/osmosis-std/src/shim.rs
+++ b/packages/osmosis-std/src/shim.rs
@@ -4,13 +4,13 @@ pub struct Timestamp {
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
     /// 9999-12-31T23:59:59Z inclusive.
     #[prost(int64, tag = "1")]
-    pub seconds: i64,
+    pub seconds: u64,
     /// Non-negative fractions of a second at nanosecond resolution. Negative
     /// second values with fractions must still have non-negative nanos values
     /// that count forward in time. Must be from 0 to 999,999,999
     /// inclusive.
     #[prost(int32, tag = "2")]
-    pub nanos: i32,
+    pub nanos: u32,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
@@ -19,7 +19,7 @@ pub struct Duration {
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
     /// 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
     #[prost(int64, tag = "1")]
-    pub seconds: i64,
+    pub seconds: u64,
     /// Signed fractions of a second at nanosecond resolution of the span
     /// of time. Durations less than one second are represented with a 0
     /// `seconds` field and a positive or negative `nanos` field. For durations
@@ -27,7 +27,7 @@ pub struct Duration {
     /// of the same sign as the `seconds` field. Must be from -999,999,999
     /// to +999,999,999 inclusive.
     #[prost(int32, tag = "2")]
-    pub nanos: i32,
+    pub nanos: u32,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]

--- a/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
@@ -9,13 +9,13 @@ pub struct EpochInfo {
     #[prost(message, optional, tag = "3")]
     pub duration: ::core::option::Option<crate::shim::Duration>,
     #[prost(int64, tag = "4")]
-    pub current_epoch: i64,
+    pub current_epoch: u64,
     #[prost(message, optional, tag = "5")]
     pub current_epoch_start_time: ::core::option::Option<crate::shim::Timestamp>,
     #[prost(bool, tag = "6")]
     pub epoch_counting_started: bool,
     #[prost(int64, tag = "8")]
-    pub current_epoch_start_height: i64,
+    pub current_epoch_start_height: u64,
 }
 /// GenesisState defines the epochs module's genesis state.
 #[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize, CosmwasmExt)]
@@ -43,5 +43,5 @@ pub struct QueryCurrentEpochRequest {
 #[proto(type_url = "/osmosis.epochs.v1beta1.QueryCurrentEpochResponse")]
 pub struct QueryCurrentEpochResponse {
     #[prost(int64, tag = "1")]
-    pub current_epoch: i64,
+    pub current_epoch: u64,
 }

--- a/packages/osmosis-std/src/types/osmosis/incentives.rs
+++ b/packages/osmosis-std/src/types/osmosis/incentives.rs
@@ -199,7 +199,7 @@ pub struct RewardsEstRequest {
     #[prost(uint64, repeated, tag = "2")]
     pub lock_ids: ::prost::alloc::vec::Vec<u64>,
     #[prost(int64, tag = "3")]
-    pub end_epoch: i64,
+    pub end_epoch: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize, CosmwasmExt)]
 #[proto(type_url = "/osmosis.incentives.RewardsEstResponse")]

--- a/packages/osmosis-std/src/types/osmosis/lockup.rs
+++ b/packages/osmosis-std/src/types/osmosis/lockup.rs
@@ -21,7 +21,7 @@ pub struct PeriodLock {
 pub struct QueryCondition {
     /// type of lock query, ByLockDuration | ByLockTime
     #[prost(enumeration = "LockQueryType", tag = "1")]
-    pub lock_query_type: i32,
+    pub lock_query_type: u32,
     /// What token denomination are we looking for lockups of
     #[prost(string, tag = "2")]
     pub denom: ::prost::alloc::string::String,
@@ -62,7 +62,7 @@ pub struct SyntheticLock {
     pub duration: ::core::option::Option<crate::shim::Duration>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum LockQueryType {
     /// Queries for locks that are longer than a certain duration
     ByDuration = 0,

--- a/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
@@ -50,7 +50,7 @@ pub struct Params {
     pub epoch_identifier: ::prost::alloc::string::String,
     /// number of epochs take to reduce rewards
     #[prost(int64, tag = "4")]
-    pub reduction_period_in_epochs: i64,
+    pub reduction_period_in_epochs: u64,
     /// reduction multiplier to execute on each period
     #[prost(string, tag = "5")]
     pub reduction_factor: ::prost::alloc::string::String,
@@ -62,7 +62,7 @@ pub struct Params {
     pub weighted_developer_rewards_receivers: ::prost::alloc::vec::Vec<WeightedAddress>,
     /// start epoch to distribute minting rewards
     #[prost(int64, tag = "8")]
-    pub minting_rewards_distribution_start_epoch: i64,
+    pub minting_rewards_distribution_start_epoch: u64,
 }
 /// QueryParamsRequest is the request type for the Query/Params RPC method.
 #[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize, CosmwasmExt)]
@@ -102,5 +102,5 @@ pub struct GenesisState {
     pub params: ::core::option::Option<Params>,
     /// current halven period start epoch
     #[prost(int64, tag = "3")]
-    pub halven_started_epoch: i64,
+    pub halven_started_epoch: u64,
 }

--- a/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
+++ b/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
@@ -7,7 +7,7 @@ pub struct SuperfluidAsset {
     #[prost(string, tag = "1")]
     pub denom: ::prost::alloc::string::String,
     #[prost(enumeration = "SuperfluidAssetType", tag = "2")]
-    pub asset_type: i32,
+    pub asset_type: u32,
 }
 /// SuperfluidIntermediaryAccount takes the role of intermediary between LP token
 /// and OSMO tokens for superfluid staking
@@ -33,7 +33,7 @@ pub struct SuperfluidIntermediaryAccount {
 #[proto(type_url = "/osmosis.superfluid.OsmoEquivalentMultiplierRecord")]
 pub struct OsmoEquivalentMultiplierRecord {
     #[prost(int64, tag = "1")]
-    pub epoch_number: i64,
+    pub epoch_number: u64,
     /// superfluid asset denom, can be LP token or native token
     #[prost(string, tag = "2")]
     pub denom: ::prost::alloc::string::String,
@@ -69,7 +69,7 @@ pub struct UnpoolWhitelistedPools {
     pub ids: ::prost::alloc::vec::Vec<u64>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
+#[repr(u32)]
 pub enum SuperfluidAssetType {
     Native = 0,
     /// SuperfluidAssetTypeLendingShare = 2; // for now not exist
@@ -180,7 +180,7 @@ pub struct AssetTypeRequest {
 #[proto(type_url = "/osmosis.superfluid.AssetTypeResponse")]
 pub struct AssetTypeResponse {
     #[prost(enumeration = "SuperfluidAssetType", tag = "1")]
-    pub asset_type: i32,
+    pub asset_type: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize, CosmwasmExt)]
 #[proto(type_url = "/osmosis.superfluid.AllAssetsRequest")]


### PR DESCRIPTION
I'm in Seoul right now doing a hackathon and happened to notice several signed integers in the `osmosis-std` package.

They're for seconds, nanoseconds, etc, and if we have them as signed ints, then we're limiting how high the number can go, since those values can never be negative.

I changed them to be unsigned since we know they'll be positive integers.

Since I'm trying to be heads-down on this hackathon, I kept my focus specific to this package and will have to move on, but want to note that there's one place that might need to be investigated and that's the `repr` macro like here:

https://github.com/osmosis-labs/osmosis-rust/compare/main...mikedotexe:osmosis-rust:make-several-ints-unsigned?expand=1#diff-03f2479269d2a37584890ff32d065ccc88fd864a9d161417eaaea30c32b9a6b2R72

Cheers