### PR TITLE
use osmosis-labs/cosmos-sdk instead of cosmos/cosmos-sdk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "dependencies/cosmos-sdk"]
 	path = dependencies/cosmos-sdk
-	url = git@github.com:cosmos/cosmos-sdk.git
+	url = https://github.com/osmosis-labs/cosmos-sdk.git
+	branch = osmosis-main
 [submodule "dependencies/osmosis"]
 	path = dependencies/osmosis
-	url = git@github.com:osmosis-labs/osmosis.git
+	url = https://github.com/osmosis-labs/osmosis.git
+	branch = main


### PR DESCRIPTION
This PR updates the repo to use the `osmosis-labs` fork of the `cosmos-sdk` rather than the `cosmos` one.

It also uses https for submodules instead of ssh.

