### PR TITLE
Osmosis queriers to not take ownership of `QuerierWrapper`

### DIFF
--- a/examples/cosmwasm/contracts/osmosis-stargate/src/contract.rs
+++ b/examples/cosmwasm/contracts/osmosis-stargate/src/contract.rs
@@ -194,7 +194,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 fn query_token_creation_fee(deps: Deps) -> StdResult<QueryTokenCreationFeeResponse> {
-    let res = TokenfactoryQuerier::new(deps.querier).params()?;
+    let res = TokenfactoryQuerier::new(&deps.querier).params()?;
     let params = res.params.ok_or(StdError::NotFound {
         kind: "osmosis_std::types::osmosis::tokenfactory::v1beta1::Params".to_string(),
     })?;
@@ -210,7 +210,7 @@ fn query_token_creation_fee(deps: Deps) -> StdResult<QueryTokenCreationFeeRespon
 
 fn query_creator_denoms(deps: Deps, env: Env) -> StdResult<QueryCreatorDenomsResponse> {
     let res =
-        TokenfactoryQuerier::new(deps.querier).denoms_from_creator(env.contract.address.into())?;
+        TokenfactoryQuerier::new(&deps.querier).denoms_from_creator(env.contract.address.into())?;
 
     Ok(QueryCreatorDenomsResponse { denoms: res.denoms })
 }

--- a/packages/osmosis-std-derive/src/lib.rs
+++ b/packages/osmosis-std-derive/src/lib.rs
@@ -51,7 +51,7 @@ pub fn derive_cosmwasm_ext(input: TokenStream) -> TokenStream {
         };
 
         let cosmwasm_query = quote! {
-            pub fn query(self, querier: cosmwasm_std::QuerierWrapper<cosmwasm_std::Empty>) -> cosmwasm_std::StdResult<#res> {
+            pub fn query(self, querier: &cosmwasm_std::QuerierWrapper<cosmwasm_std::Empty>) -> cosmwasm_std::StdResult<#res> {
                 querier.query::<#res>(&self.into())
             }
         };

--- a/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
@@ -137,10 +137,10 @@ pub struct QueryCurrentEpochResponse {
     pub current_epoch: i64,
 }
 pub struct EpochsQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> EpochsQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn epoch_infos(&self) -> Result<QueryEpochsInfoResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/gamm/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/gamm/v1beta1.rs
@@ -836,10 +836,10 @@ pub struct GenesisState {
     pub params: ::core::option::Option<Params>,
 }
 pub struct GammQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> GammQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn pools(

--- a/packages/osmosis-std/src/types/osmosis/incentives.rs
+++ b/packages/osmosis-std/src/types/osmosis/incentives.rs
@@ -500,10 +500,10 @@ pub struct GenesisState {
     pub last_gauge_id: u64,
 }
 pub struct IncentivesQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> IncentivesQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn module_to_distribute_coins(

--- a/packages/osmosis-std/src/types/osmosis/lockup.rs
+++ b/packages/osmosis-std/src/types/osmosis/lockup.rs
@@ -767,10 +767,10 @@ pub struct GenesisState {
     pub synthetic_locks: ::prost::alloc::vec::Vec<SyntheticLock>,
 }
 pub struct LockupQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> LockupQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn module_balance(&self) -> Result<ModuleBalanceResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
@@ -185,10 +185,10 @@ pub struct GenesisState {
     pub halven_started_epoch: i64,
 }
 pub struct MintQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> MintQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/poolincentives/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/poolincentives/v1beta1.rs
@@ -352,10 +352,10 @@ pub struct GenesisState {
     pub distr_info: ::core::option::Option<DistrInfo>,
 }
 pub struct PoolincentivesQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> PoolincentivesQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn gauge_ids(&self, pool_id: u64) -> Result<QueryGaugeIdsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
+++ b/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
@@ -744,10 +744,10 @@ pub struct GenesisState {
         ::prost::alloc::vec::Vec<LockIdIntermediaryAccountConnection>,
 }
 pub struct SuperfluidQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> SuperfluidQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/tokenfactory/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/tokenfactory/v1beta1.rs
@@ -293,10 +293,10 @@ pub struct GenesisDenom {
     pub authority_metadata: ::core::option::Option<DenomAuthorityMetadata>,
 }
 pub struct TokenfactoryQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> TokenfactoryQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/txfees/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/txfees/v1beta1.rs
@@ -188,10 +188,10 @@ pub struct GenesisState {
     pub feetokens: ::prost::alloc::vec::Vec<FeeToken>,
 }
 pub struct TxfeesQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> TxfeesQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn fee_tokens(&self) -> Result<QueryFeeTokensResponse, cosmwasm_std::StdError> {

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -225,12 +225,12 @@ pub fn append_querier(
             vec![
                 parse_quote! {
                   pub struct #querier_wrapper_ident<'a> {
-                    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>
+                    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>
                   }
                 },
                 parse_quote! {
                   impl<'a> #querier_wrapper_ident<'a> {
-                    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+                    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
                       Self { querier }
                     }
                     #(#query_fns)*


### PR DESCRIPTION
Closes: https://github.com/osmosis-labs/osmosis-rust/issues/36

Tbh, haven't been able to test this yet. Tried it on LocalOsmoisis, which seems to be based on an older version of osmosisd (v10) and doesn't support Stargate queries.