### PR TITLE
boss/generic querier

### DIFF
--- a/examples/cosmwasm/contracts/osmosis-stargate/Cargo.toml
+++ b/examples/cosmwasm/contracts/osmosis-stargate/Cargo.toml
@@ -44,6 +44,7 @@ cosmwasm-std = {version = "1.0.0", features = ["stargate"]}
 cosmwasm-storage = "1.0.0"
 cw-storage-plus = "0.13.2"
 cw2 = "0.13.2"
+osmo-bindings = "0.5.1"
 osmosis-std = {path = "../../../../packages/osmosis-std", version = "0.1.2"}
 prost = "0.10.4"
 schemars = "0.8.8"

--- a/examples/cosmwasm/contracts/osmosis-stargate/src/contract.rs
+++ b/examples/cosmwasm/contracts/osmosis-stargate/src/contract.rs
@@ -7,6 +7,7 @@ use cosmwasm_std::{
     StdResult, SubMsg, SubMsgResponse, SubMsgResult,
 };
 use cw2::set_contract_version;
+use osmo_bindings::OsmosisQuery;
 use osmosis_std::types::cosmos::base::v1beta1::Coin;
 use osmosis_std::types::osmosis::gamm::poolmodels::balancer::v1beta1::{
     MsgCreateBalancerPool, MsgCreateBalancerPoolResponse,
@@ -186,14 +187,20 @@ pub fn try_create_balancer_pool(env: Env, subdenom: String) -> Result<Response, 
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(
+    // use Deps<OsmosisQuery> tp test if chain's native querier can wrap
+    // generic querier instead of restricted to `QuerierWrapper<Empty>`
+    deps: Deps<OsmosisQuery>,
+    env: Env,
+    msg: QueryMsg,
+) -> StdResult<Binary> {
     match msg {
         QueryMsg::QueryTokenCreationFee {} => to_binary(&query_token_creation_fee(deps)?),
         QueryMsg::QueryCreatorDenoms {} => to_binary(&query_creator_denoms(deps, env)?),
     }
 }
 
-fn query_token_creation_fee(deps: Deps) -> StdResult<QueryTokenCreationFeeResponse> {
+fn query_token_creation_fee(deps: Deps<OsmosisQuery>) -> StdResult<QueryTokenCreationFeeResponse> {
     let res = TokenfactoryQuerier::new(&deps.querier).params()?;
     let params = res.params.ok_or(StdError::NotFound {
         kind: "osmosis_std::types::osmosis::tokenfactory::v1beta1::Params".to_string(),
@@ -208,7 +215,10 @@ fn query_token_creation_fee(deps: Deps) -> StdResult<QueryTokenCreationFeeRespon
     Ok(QueryTokenCreationFeeResponse { fee })
 }
 
-fn query_creator_denoms(deps: Deps, env: Env) -> StdResult<QueryCreatorDenomsResponse> {
+fn query_creator_denoms(
+    deps: Deps<OsmosisQuery>,
+    env: Env,
+) -> StdResult<QueryCreatorDenomsResponse> {
     let res =
         TokenfactoryQuerier::new(&deps.querier).denoms_from_creator(env.contract.address.into())?;
 

--- a/examples/cosmwasm/contracts/osmosis-stargate/src/contract.rs
+++ b/examples/cosmwasm/contracts/osmosis-stargate/src/contract.rs
@@ -194,7 +194,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 fn query_token_creation_fee(deps: Deps) -> StdResult<QueryTokenCreationFeeResponse> {
-    let res = TokenfactoryQuerier::new(deps.querier).params()?;
+    let res = TokenfactoryQuerier::new(&deps.querier).params()?;
     let params = res.params.ok_or(StdError::NotFound {
         kind: "osmosis_std::types::osmosis::tokenfactory::v1beta1::Params".to_string(),
     })?;
@@ -210,7 +210,7 @@ fn query_token_creation_fee(deps: Deps) -> StdResult<QueryTokenCreationFeeRespon
 
 fn query_creator_denoms(deps: Deps, env: Env) -> StdResult<QueryCreatorDenomsResponse> {
     let res =
-        TokenfactoryQuerier::new(deps.querier).denoms_from_creator(env.contract.address.into())?;
+        TokenfactoryQuerier::new(&deps.querier).denoms_from_creator(env.contract.address.into())?;
 
     Ok(QueryCreatorDenomsResponse { denoms: res.denoms })
 }

--- a/packages/osmosis-std-derive/src/lib.rs
+++ b/packages/osmosis-std-derive/src/lib.rs
@@ -51,7 +51,7 @@ pub fn derive_cosmwasm_ext(input: TokenStream) -> TokenStream {
         };
 
         let cosmwasm_query = quote! {
-            pub fn query(self, querier: cosmwasm_std::QuerierWrapper<cosmwasm_std::Empty>) -> cosmwasm_std::StdResult<#res> {
+            pub fn query(self, querier: &cosmwasm_std::QuerierWrapper<cosmwasm_std::Empty>) -> cosmwasm_std::StdResult<#res> {
                 querier.query::<#res>(&self.into())
             }
         };

--- a/packages/osmosis-std-derive/src/lib.rs
+++ b/packages/osmosis-std-derive/src/lib.rs
@@ -40,9 +40,9 @@ pub fn derive_cosmwasm_ext(input: TokenStream) -> TokenStream {
         let res = get_query_attrs(&input.attrs, match_kv_attr!("response_type", Ident));
 
         let query_request_conversion = quote! {
-            impl From<#ident> for cosmwasm_std::QueryRequest<cosmwasm_std::Empty> {
+            impl <Q: cosmwasm_std::CustomQuery> From<#ident> for cosmwasm_std::QueryRequest<Q> {
                 fn from(msg: #ident) -> Self {
-                    cosmwasm_std::QueryRequest::<cosmwasm_std::Empty>::Stargate {
+                    cosmwasm_std::QueryRequest::<Q>::Stargate {
                         path: #path.to_string(),
                         data: msg.into(),
                     }
@@ -51,7 +51,7 @@ pub fn derive_cosmwasm_ext(input: TokenStream) -> TokenStream {
         };
 
         let cosmwasm_query = quote! {
-            pub fn query(self, querier: &cosmwasm_std::QuerierWrapper<cosmwasm_std::Empty>) -> cosmwasm_std::StdResult<#res> {
+            pub fn query(self, querier: &cosmwasm_std::QuerierWrapper<impl cosmwasm_std::CustomQuery>) -> cosmwasm_std::StdResult<#res> {
                 querier.query::<#res>(&self.into())
             }
         };

--- a/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
@@ -137,10 +137,10 @@ pub struct QueryCurrentEpochResponse {
     pub current_epoch: i64,
 }
 pub struct EpochsQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> EpochsQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn epoch_infos(&self) -> Result<QueryEpochsInfoResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/epochs/v1beta1.rs
@@ -136,11 +136,11 @@ pub struct QueryCurrentEpochResponse {
     #[prost(int64, tag = "1")]
     pub current_epoch: i64,
 }
-pub struct EpochsQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct EpochsQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> EpochsQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> EpochsQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn epoch_infos(&self) -> Result<QueryEpochsInfoResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/gamm/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/gamm/v1beta1.rs
@@ -835,11 +835,11 @@ pub struct GenesisState {
     #[prost(message, optional, tag = "3")]
     pub params: ::core::option::Option<Params>,
 }
-pub struct GammQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct GammQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> GammQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> GammQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn pools(

--- a/packages/osmosis-std/src/types/osmosis/gamm/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/gamm/v1beta1.rs
@@ -836,10 +836,10 @@ pub struct GenesisState {
     pub params: ::core::option::Option<Params>,
 }
 pub struct GammQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> GammQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn pools(

--- a/packages/osmosis-std/src/types/osmosis/incentives.rs
+++ b/packages/osmosis-std/src/types/osmosis/incentives.rs
@@ -499,11 +499,11 @@ pub struct GenesisState {
     #[prost(uint64, tag = "4")]
     pub last_gauge_id: u64,
 }
-pub struct IncentivesQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct IncentivesQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> IncentivesQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> IncentivesQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn module_to_distribute_coins(

--- a/packages/osmosis-std/src/types/osmosis/incentives.rs
+++ b/packages/osmosis-std/src/types/osmosis/incentives.rs
@@ -500,10 +500,10 @@ pub struct GenesisState {
     pub last_gauge_id: u64,
 }
 pub struct IncentivesQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> IncentivesQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn module_to_distribute_coins(

--- a/packages/osmosis-std/src/types/osmosis/lockup.rs
+++ b/packages/osmosis-std/src/types/osmosis/lockup.rs
@@ -767,10 +767,10 @@ pub struct GenesisState {
     pub synthetic_locks: ::prost::alloc::vec::Vec<SyntheticLock>,
 }
 pub struct LockupQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> LockupQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn module_balance(&self) -> Result<ModuleBalanceResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/lockup.rs
+++ b/packages/osmosis-std/src/types/osmosis/lockup.rs
@@ -766,11 +766,11 @@ pub struct GenesisState {
     #[prost(message, repeated, tag = "3")]
     pub synthetic_locks: ::prost::alloc::vec::Vec<SyntheticLock>,
 }
-pub struct LockupQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct LockupQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> LockupQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> LockupQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn module_balance(&self) -> Result<ModuleBalanceResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
@@ -185,10 +185,10 @@ pub struct GenesisState {
     pub halven_started_epoch: i64,
 }
 pub struct MintQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> MintQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/mint/v1beta1.rs
@@ -184,11 +184,11 @@ pub struct GenesisState {
     #[prost(int64, tag = "3")]
     pub halven_started_epoch: i64,
 }
-pub struct MintQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct MintQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> MintQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> MintQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/poolincentives/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/poolincentives/v1beta1.rs
@@ -351,11 +351,11 @@ pub struct GenesisState {
     #[prost(message, optional, tag = "3")]
     pub distr_info: ::core::option::Option<DistrInfo>,
 }
-pub struct PoolincentivesQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct PoolincentivesQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> PoolincentivesQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> PoolincentivesQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn gauge_ids(&self, pool_id: u64) -> Result<QueryGaugeIdsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/poolincentives/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/poolincentives/v1beta1.rs
@@ -352,10 +352,10 @@ pub struct GenesisState {
     pub distr_info: ::core::option::Option<DistrInfo>,
 }
 pub struct PoolincentivesQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> PoolincentivesQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn gauge_ids(&self, pool_id: u64) -> Result<QueryGaugeIdsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
+++ b/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
@@ -743,11 +743,11 @@ pub struct GenesisState {
     pub intemediary_account_connections:
         ::prost::alloc::vec::Vec<LockIdIntermediaryAccountConnection>,
 }
-pub struct SuperfluidQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct SuperfluidQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> SuperfluidQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> SuperfluidQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
+++ b/packages/osmosis-std/src/types/osmosis/superfluid/mod.rs
@@ -744,10 +744,10 @@ pub struct GenesisState {
         ::prost::alloc::vec::Vec<LockIdIntermediaryAccountConnection>,
 }
 pub struct SuperfluidQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> SuperfluidQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/tokenfactory/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/tokenfactory/v1beta1.rs
@@ -292,11 +292,11 @@ pub struct GenesisDenom {
     #[prost(message, optional, tag = "2")]
     pub authority_metadata: ::core::option::Option<DenomAuthorityMetadata>,
 }
-pub struct TokenfactoryQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct TokenfactoryQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> TokenfactoryQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> TokenfactoryQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/tokenfactory/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/tokenfactory/v1beta1.rs
@@ -293,10 +293,10 @@ pub struct GenesisDenom {
     pub authority_metadata: ::core::option::Option<DenomAuthorityMetadata>,
 }
 pub struct TokenfactoryQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> TokenfactoryQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn params(&self) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/txfees/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/txfees/v1beta1.rs
@@ -187,11 +187,11 @@ pub struct GenesisState {
     #[prost(message, repeated, tag = "2")]
     pub feetokens: ::prost::alloc::vec::Vec<FeeToken>,
 }
-pub struct TxfeesQuerier<'a> {
-    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+pub struct TxfeesQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
 }
-impl<'a> TxfeesQuerier<'a> {
-    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+impl<'a, Q: cosmwasm_std::CustomQuery> TxfeesQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
         Self { querier }
     }
     pub fn fee_tokens(&self) -> Result<QueryFeeTokensResponse, cosmwasm_std::StdError> {

--- a/packages/osmosis-std/src/types/osmosis/txfees/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/txfees/v1beta1.rs
@@ -188,10 +188,10 @@ pub struct GenesisState {
     pub feetokens: ::prost::alloc::vec::Vec<FeeToken>,
 }
 pub struct TxfeesQuerier<'a> {
-    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>,
 }
 impl<'a> TxfeesQuerier<'a> {
-    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
         Self { querier }
     }
     pub fn fee_tokens(&self) -> Result<QueryFeeTokensResponse, cosmwasm_std::StdError> {

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -225,12 +225,12 @@ pub fn append_querier(
             vec![
                 parse_quote! {
                   pub struct #querier_wrapper_ident<'a> {
-                    querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>
+                    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>
                   }
                 },
                 parse_quote! {
                   impl<'a> #querier_wrapper_ident<'a> {
-                    pub fn new(querier: cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
+                    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
                       Self { querier }
                     }
                     #(#query_fns)*

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -224,14 +224,14 @@ pub fn append_querier(
         if !nested_mod {
             vec![
                 parse_quote! {
-                  pub struct #querier_wrapper_ident<'a> {
-                    querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>
+                  pub struct #querier_wrapper_ident<'a, Q: cosmwasm_std::CustomQuery> {
+                      querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
                   }
                 },
                 parse_quote! {
-                  impl<'a> #querier_wrapper_ident<'a> {
-                    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, cosmwasm_std::Empty>) -> Self {
-                      Self { querier }
+                  impl<'a, Q: cosmwasm_std::CustomQuery> #querier_wrapper_ident<'a, Q> {
+                      pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
+                    Self { querier }
                     }
                     #(#query_fns)*
                   }


### PR DESCRIPTION
- Osmosis queriers do not take ownership of `QuerierWrapper`
- allow native module's queier wrapper to accept generic QuerierWrapper
