### PR TITLE
feat: Add backtraces feature for cosmwasm-std Errors

### DIFF
--- a/packages/osmosis-std-derive/Cargo.toml
+++ b/packages/osmosis-std-derive/Cargo.toml
@@ -7,6 +7,9 @@ version = "0.15.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+
 [lib]
 proc-macro = true
 

--- a/packages/osmosis-std/Cargo.toml
+++ b/packages/osmosis-std/Cargo.toml
@@ -7,6 +7,9 @@ version = "0.15.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+backtraces = ["cosmwasm-std/backtraces", "osmosis-std-derive/backtraces"]
+
 [dependencies]
 chrono = {version = "0.4.22", default-features = false}
 cosmwasm-std = {version = "1.1.2", features = ["stargate"]}

--- a/packages/osmosis-std/src/types/cosmos/gov/mod.rs
+++ b/packages/osmosis-std/src/types/cosmos/gov/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1beta1;

--- a/packages/osmosis-std/src/types/cosmos/gov/v1beta1.rs
+++ b/packages/osmosis-std/src/types/cosmos/gov/v1beta1.rs
@@ -1,0 +1,1061 @@
+use osmosis_std_derive::CosmwasmExt;
+/// WeightedVoteOption defines a unit of vote for vote split.
+///
+/// Since: cosmos-sdk 0.43
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.WeightedVoteOption")]
+pub struct WeightedVoteOption {
+    #[prost(enumeration = "VoteOption", tag = "1")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub option: i32,
+    #[prost(string, tag = "2")]
+    pub weight: ::prost::alloc::string::String,
+}
+/// TextProposal defines a standard text proposal whose changes need to be
+/// manually updated in case of approval.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.TextProposal")]
+pub struct TextProposal {
+    #[prost(string, tag = "1")]
+    pub title: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub description: ::prost::alloc::string::String,
+}
+/// Deposit defines an amount deposited by an account address to an active
+/// proposal.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.Deposit")]
+pub struct Deposit {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// Proposal defines the core field members of a governance proposal.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.Proposal")]
+pub struct Proposal {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    #[prost(message, optional, tag = "2")]
+    pub content: ::core::option::Option<crate::shim::Any>,
+    #[prost(enumeration = "ProposalStatus", tag = "3")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub status: i32,
+    #[prost(message, optional, tag = "4")]
+    pub final_tally_result: ::core::option::Option<TallyResult>,
+    #[prost(message, optional, tag = "5")]
+    pub submit_time: ::core::option::Option<crate::shim::Timestamp>,
+    #[prost(message, optional, tag = "6")]
+    pub deposit_end_time: ::core::option::Option<crate::shim::Timestamp>,
+    #[prost(message, repeated, tag = "7")]
+    pub total_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(message, optional, tag = "8")]
+    pub voting_start_time: ::core::option::Option<crate::shim::Timestamp>,
+    #[prost(message, optional, tag = "9")]
+    pub voting_end_time: ::core::option::Option<crate::shim::Timestamp>,
+    #[prost(bool, tag = "10")]
+    pub is_expedited: bool,
+}
+/// TallyResult defines a standard tally for a governance proposal.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.TallyResult")]
+pub struct TallyResult {
+    #[prost(string, tag = "1")]
+    pub yes: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub abstain: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub no: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub no_with_veto: ::prost::alloc::string::String,
+}
+/// Vote defines a vote on a governance proposal.
+/// A Vote consists of a proposal ID, the voter, and the vote option.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.Vote")]
+pub struct Vote {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    /// Deprecated: Prefer to use `options` instead. This field is set in queries
+    /// if and only if `len(options) == 1` and that option has weight 1. In all
+    /// other cases, this field will default to VOTE_OPTION_UNSPECIFIED.
+    #[deprecated]
+    #[prost(enumeration = "VoteOption", tag = "3")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub option: i32,
+    /// Since: cosmos-sdk 0.43
+    #[prost(message, repeated, tag = "4")]
+    pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
+}
+/// DepositParams defines the params for deposits on governance proposals.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.DepositParams")]
+pub struct DepositParams {
+    ///   Minimum deposit for a proposal to enter voting period.
+    #[prost(message, repeated, tag = "1")]
+    pub min_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    ///   Maximum period for Atom holders to deposit on a proposal. Initial value: 2
+    ///   months.
+    #[prost(message, optional, tag = "2")]
+    pub max_deposit_period: ::core::option::Option<crate::shim::Duration>,
+    ///   Minimum expedited deposit for a proposal to enter voting period.
+    #[prost(message, repeated, tag = "3")]
+    pub min_expedited_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    ///   The ratio representing the proportion of the deposit value that must be paid at proposal submission.
+    #[prost(string, tag = "4")]
+    pub min_initial_deposit_ratio: ::prost::alloc::string::String,
+}
+/// VotingParams defines the params for voting on governance proposals.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.VotingParams")]
+pub struct VotingParams {
+    /// voting_period defines the length of the voting period.
+    #[prost(message, optional, tag = "1")]
+    pub voting_period: ::core::option::Option<crate::shim::Duration>,
+    /// proposal_voting_periods defines custom voting periods for proposal types.
+    #[prost(message, repeated, tag = "2")]
+    pub proposal_voting_periods: ::prost::alloc::vec::Vec<ProposalVotingPeriod>,
+    /// Length of the expedited voting period.
+    #[prost(message, optional, tag = "3")]
+    pub expedited_voting_period: ::core::option::Option<crate::shim::Duration>,
+}
+/// TallyParams defines the params for tallying votes on governance proposals.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.TallyParams")]
+pub struct TallyParams {
+    ///   Minimum percentage of total stake needed to vote for a result to be
+    ///   considered valid.
+    #[prost(bytes = "vec", tag = "1")]
+    pub quorum: ::prost::alloc::vec::Vec<u8>,
+    ///   Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
+    #[prost(bytes = "vec", tag = "2")]
+    pub threshold: ::prost::alloc::vec::Vec<u8>,
+    ///   Minimum value of Veto votes to Total votes ratio for proposal to be
+    ///   vetoed. Default value: 1/3.
+    #[prost(bytes = "vec", tag = "3")]
+    pub veto_threshold: ::prost::alloc::vec::Vec<u8>,
+    ///   Minimum proportion of Yes votes for an expedited proposal to pass. Default value: 0.67.
+    #[prost(bytes = "vec", tag = "4")]
+    pub expedited_threshold: ::prost::alloc::vec::Vec<u8>,
+    ///   Minimum proportion of Yes votes for an expedited proposal to reach quorum. Default value: 0.67.
+    #[prost(bytes = "vec", tag = "5")]
+    pub expedited_quorum: ::prost::alloc::vec::Vec<u8>,
+}
+/// ProposalVotingPeriod defines custom voting periods for a unique governance
+/// proposal type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.ProposalVotingPeriod")]
+pub struct ProposalVotingPeriod {
+    /// e.g. "cosmos.params.v1beta1.ParameterChangeProposal"
+    #[prost(string, tag = "1")]
+    pub proposal_type: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub voting_period: ::core::option::Option<crate::shim::Duration>,
+}
+/// VoteOption enumerates the valid vote options for a given governance proposal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+#[derive(::serde::Serialize, ::serde::Deserialize, ::schemars::JsonSchema)]
+pub enum VoteOption {
+    /// VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+    Unspecified = 0,
+    /// VOTE_OPTION_YES defines a yes vote option.
+    Yes = 1,
+    /// VOTE_OPTION_ABSTAIN defines an abstain vote option.
+    Abstain = 2,
+    /// VOTE_OPTION_NO defines a no vote option.
+    No = 3,
+    /// VOTE_OPTION_NO_WITH_VETO defines a no with veto vote option.
+    NoWithVeto = 4,
+}
+impl VoteOption {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            VoteOption::Unspecified => "VOTE_OPTION_UNSPECIFIED",
+            VoteOption::Yes => "VOTE_OPTION_YES",
+            VoteOption::Abstain => "VOTE_OPTION_ABSTAIN",
+            VoteOption::No => "VOTE_OPTION_NO",
+            VoteOption::NoWithVeto => "VOTE_OPTION_NO_WITH_VETO",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VOTE_OPTION_UNSPECIFIED" => Some(Self::Unspecified),
+            "VOTE_OPTION_YES" => Some(Self::Yes),
+            "VOTE_OPTION_ABSTAIN" => Some(Self::Abstain),
+            "VOTE_OPTION_NO" => Some(Self::No),
+            "VOTE_OPTION_NO_WITH_VETO" => Some(Self::NoWithVeto),
+            _ => None,
+        }
+    }
+}
+/// ProposalStatus enumerates the valid statuses of a proposal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+#[derive(::serde::Serialize, ::serde::Deserialize, ::schemars::JsonSchema)]
+pub enum ProposalStatus {
+    /// PROPOSAL_STATUS_UNSPECIFIED defines the default propopsal status.
+    Unspecified = 0,
+    /// PROPOSAL_STATUS_DEPOSIT_PERIOD defines a proposal status during the deposit
+    /// period.
+    DepositPeriod = 1,
+    /// PROPOSAL_STATUS_VOTING_PERIOD defines a proposal status during the voting
+    /// period.
+    VotingPeriod = 2,
+    /// PROPOSAL_STATUS_PASSED defines a proposal status of a proposal that has
+    /// passed.
+    Passed = 3,
+    /// PROPOSAL_STATUS_REJECTED defines a proposal status of a proposal that has
+    /// been rejected.
+    Rejected = 4,
+    /// PROPOSAL_STATUS_FAILED defines a proposal status of a proposal that has
+    /// failed.
+    Failed = 5,
+}
+impl ProposalStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ProposalStatus::Unspecified => "PROPOSAL_STATUS_UNSPECIFIED",
+            ProposalStatus::DepositPeriod => "PROPOSAL_STATUS_DEPOSIT_PERIOD",
+            ProposalStatus::VotingPeriod => "PROPOSAL_STATUS_VOTING_PERIOD",
+            ProposalStatus::Passed => "PROPOSAL_STATUS_PASSED",
+            ProposalStatus::Rejected => "PROPOSAL_STATUS_REJECTED",
+            ProposalStatus::Failed => "PROPOSAL_STATUS_FAILED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PROPOSAL_STATUS_UNSPECIFIED" => Some(Self::Unspecified),
+            "PROPOSAL_STATUS_DEPOSIT_PERIOD" => Some(Self::DepositPeriod),
+            "PROPOSAL_STATUS_VOTING_PERIOD" => Some(Self::VotingPeriod),
+            "PROPOSAL_STATUS_PASSED" => Some(Self::Passed),
+            "PROPOSAL_STATUS_REJECTED" => Some(Self::Rejected),
+            "PROPOSAL_STATUS_FAILED" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+/// GenesisState defines the gov module's genesis state.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.GenesisState")]
+pub struct GenesisState {
+    /// starting_proposal_id is the ID of the starting proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "starting_proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub starting_proposal_id: u64,
+    /// deposits defines all the deposits present at genesis.
+    #[prost(message, repeated, tag = "2")]
+    pub deposits: ::prost::alloc::vec::Vec<Deposit>,
+    /// votes defines all the votes present at genesis.
+    #[prost(message, repeated, tag = "3")]
+    pub votes: ::prost::alloc::vec::Vec<Vote>,
+    /// proposals defines all the proposals present at genesis.
+    #[prost(message, repeated, tag = "4")]
+    pub proposals: ::prost::alloc::vec::Vec<Proposal>,
+    /// params defines all the paramaters of related to deposit.
+    #[prost(message, optional, tag = "5")]
+    pub deposit_params: ::core::option::Option<DepositParams>,
+    /// params defines all the paramaters of related to voting.
+    #[prost(message, optional, tag = "6")]
+    pub voting_params: ::core::option::Option<VotingParams>,
+    /// params defines all the paramaters of related to tally.
+    #[prost(message, optional, tag = "7")]
+    pub tally_params: ::core::option::Option<TallyParams>,
+}
+/// QueryProposalRequest is the request type for the Query/Proposal RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryProposalRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Proposal",
+    response_type = QueryProposalResponse
+)]
+pub struct QueryProposalRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+}
+/// QueryProposalResponse is the response type for the Query/Proposal RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryProposalResponse")]
+pub struct QueryProposalResponse {
+    #[prost(message, optional, tag = "1")]
+    pub proposal: ::core::option::Option<Proposal>,
+}
+/// QueryProposalsRequest is the request type for the Query/Proposals RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryProposalsRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Proposals",
+    response_type = QueryProposalsResponse
+)]
+pub struct QueryProposalsRequest {
+    /// proposal_status defines the status of the proposals.
+    #[prost(enumeration = "ProposalStatus", tag = "1")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_status: i32,
+    /// voter defines the voter address for the proposals.
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    /// depositor defines the deposit addresses from the proposals.
+    #[prost(string, tag = "3")]
+    pub depositor: ::prost::alloc::string::String,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "4")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryProposalsResponse is the response type for the Query/Proposals RPC
+/// method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryProposalsResponse")]
+pub struct QueryProposalsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub proposals: ::prost::alloc::vec::Vec<Proposal>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryVoteRequest is the request type for the Query/Vote RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryVoteRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Vote",
+    response_type = QueryVoteResponse
+)]
+pub struct QueryVoteRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    /// voter defines the oter address for the proposals.
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+}
+/// QueryVoteResponse is the response type for the Query/Vote RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryVoteResponse")]
+pub struct QueryVoteResponse {
+    /// vote defined the queried vote.
+    #[prost(message, optional, tag = "1")]
+    pub vote: ::core::option::Option<Vote>,
+}
+/// QueryVotesRequest is the request type for the Query/Votes RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryVotesRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Votes",
+    response_type = QueryVotesResponse
+)]
+pub struct QueryVotesRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryVotesResponse is the response type for the Query/Votes RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryVotesResponse")]
+pub struct QueryVotesResponse {
+    /// votes defined the queried votes.
+    #[prost(message, repeated, tag = "1")]
+    pub votes: ::prost::alloc::vec::Vec<Vote>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryParamsRequest is the request type for the Query/Params RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryParamsRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Params",
+    response_type = QueryParamsResponse
+)]
+pub struct QueryParamsRequest {
+    /// params_type defines which parameters to query for, can be one of "voting",
+    /// "tallying" or "deposit".
+    #[prost(string, tag = "1")]
+    pub params_type: ::prost::alloc::string::String,
+}
+/// QueryParamsResponse is the response type for the Query/Params RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryParamsResponse")]
+pub struct QueryParamsResponse {
+    /// voting_params defines the parameters related to voting.
+    #[prost(message, optional, tag = "1")]
+    pub voting_params: ::core::option::Option<VotingParams>,
+    /// deposit_params defines the parameters related to deposit.
+    #[prost(message, optional, tag = "2")]
+    pub deposit_params: ::core::option::Option<DepositParams>,
+    /// tally_params defines the parameters related to tally.
+    #[prost(message, optional, tag = "3")]
+    pub tally_params: ::core::option::Option<TallyParams>,
+}
+/// QueryDepositRequest is the request type for the Query/Deposit RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryDepositRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Deposit",
+    response_type = QueryDepositResponse
+)]
+pub struct QueryDepositRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    /// depositor defines the deposit addresses from the proposals.
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+}
+/// QueryDepositResponse is the response type for the Query/Deposit RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryDepositResponse")]
+pub struct QueryDepositResponse {
+    /// deposit defines the requested deposit.
+    #[prost(message, optional, tag = "1")]
+    pub deposit: ::core::option::Option<Deposit>,
+}
+/// QueryDepositsRequest is the request type for the Query/Deposits RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryDepositsRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/Deposits",
+    response_type = QueryDepositsResponse
+)]
+pub struct QueryDepositsRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    /// pagination defines an optional pagination for the request.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+}
+/// QueryDepositsResponse is the response type for the Query/Deposits RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryDepositsResponse")]
+pub struct QueryDepositsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub deposits: ::prost::alloc::vec::Vec<Deposit>,
+    /// pagination defines the pagination in the response.
+    #[prost(message, optional, tag = "2")]
+    pub pagination: ::core::option::Option<super::super::base::query::v1beta1::PageResponse>,
+}
+/// QueryTallyResultRequest is the request type for the Query/Tally RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryTallyResultRequest")]
+#[proto_query(
+    path = "/cosmos.gov.v1beta1.Query/TallyResult",
+    response_type = QueryTallyResultResponse
+)]
+pub struct QueryTallyResultRequest {
+    /// proposal_id defines the unique id of the proposal.
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+}
+/// QueryTallyResultResponse is the response type for the Query/Tally RPC method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.QueryTallyResultResponse")]
+pub struct QueryTallyResultResponse {
+    /// tally defines the requested tally.
+    #[prost(message, optional, tag = "1")]
+    pub tally: ::core::option::Option<TallyResult>,
+}
+/// MsgSubmitProposal defines an sdk.Msg type that supports submitting arbitrary
+/// proposal Content.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgSubmitProposal")]
+pub struct MsgSubmitProposal {
+    #[prost(message, optional, tag = "1")]
+    pub content: ::core::option::Option<crate::shim::Any>,
+    #[prost(message, repeated, tag = "2")]
+    pub initial_deposit: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+    #[prost(string, tag = "3")]
+    pub proposer: ::prost::alloc::string::String,
+    #[prost(bool, tag = "4")]
+    pub is_expedited: bool,
+}
+/// MsgSubmitProposalResponse defines the Msg/SubmitProposal response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgSubmitProposalResponse")]
+pub struct MsgSubmitProposalResponse {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+}
+/// MsgVote defines a message to cast a vote.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgVote")]
+pub struct MsgVote {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    #[prost(enumeration = "VoteOption", tag = "3")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub option: i32,
+}
+/// MsgVoteResponse defines the Msg/Vote response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgVoteResponse")]
+pub struct MsgVoteResponse {}
+/// MsgVoteWeighted defines a message to cast a vote.
+///
+/// Since: cosmos-sdk 0.43
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgVoteWeighted")]
+pub struct MsgVoteWeighted {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub voter: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub options: ::prost::alloc::vec::Vec<WeightedVoteOption>,
+}
+/// MsgVoteWeightedResponse defines the Msg/VoteWeighted response type.
+///
+/// Since: cosmos-sdk 0.43
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgVoteWeightedResponse")]
+pub struct MsgVoteWeightedResponse {}
+/// MsgDeposit defines a message to submit a deposit to an existing proposal.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgDeposit")]
+pub struct MsgDeposit {
+    #[prost(uint64, tag = "1")]
+    #[serde(alias = "proposalID")]
+    #[serde(
+        serialize_with = "crate::serde::as_str::serialize",
+        deserialize_with = "crate::serde::as_str::deserialize"
+    )]
+    pub proposal_id: u64,
+    #[prost(string, tag = "2")]
+    pub depositor: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "3")]
+    pub amount: ::prost::alloc::vec::Vec<super::super::base::v1beta1::Coin>,
+}
+/// MsgDepositResponse defines the Msg/Deposit response type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.gov.v1beta1.MsgDepositResponse")]
+pub struct MsgDepositResponse {}
+pub struct GovQuerier<'a, Q: cosmwasm_std::CustomQuery> {
+    querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>,
+}
+impl<'a, Q: cosmwasm_std::CustomQuery> GovQuerier<'a, Q> {
+    pub fn new(querier: &'a cosmwasm_std::QuerierWrapper<'a, Q>) -> Self {
+        Self { querier }
+    }
+    pub fn proposal(
+        &self,
+        proposal_id: u64,
+    ) -> Result<QueryProposalResponse, cosmwasm_std::StdError> {
+        QueryProposalRequest { proposal_id }.query(self.querier)
+    }
+    pub fn proposals(
+        &self,
+        proposal_status: i32,
+        voter: ::prost::alloc::string::String,
+        depositor: ::prost::alloc::string::String,
+        pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    ) -> Result<QueryProposalsResponse, cosmwasm_std::StdError> {
+        QueryProposalsRequest {
+            proposal_status,
+            voter,
+            depositor,
+            pagination,
+        }
+        .query(self.querier)
+    }
+    pub fn vote(
+        &self,
+        proposal_id: u64,
+        voter: ::prost::alloc::string::String,
+    ) -> Result<QueryVoteResponse, cosmwasm_std::StdError> {
+        QueryVoteRequest { proposal_id, voter }.query(self.querier)
+    }
+    pub fn votes(
+        &self,
+        proposal_id: u64,
+        pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    ) -> Result<QueryVotesResponse, cosmwasm_std::StdError> {
+        QueryVotesRequest {
+            proposal_id,
+            pagination,
+        }
+        .query(self.querier)
+    }
+    pub fn params(
+        &self,
+        params_type: ::prost::alloc::string::String,
+    ) -> Result<QueryParamsResponse, cosmwasm_std::StdError> {
+        QueryParamsRequest { params_type }.query(self.querier)
+    }
+    pub fn deposit(
+        &self,
+        proposal_id: u64,
+        depositor: ::prost::alloc::string::String,
+    ) -> Result<QueryDepositResponse, cosmwasm_std::StdError> {
+        QueryDepositRequest {
+            proposal_id,
+            depositor,
+        }
+        .query(self.querier)
+    }
+    pub fn deposits(
+        &self,
+        proposal_id: u64,
+        pagination: ::core::option::Option<super::super::base::query::v1beta1::PageRequest>,
+    ) -> Result<QueryDepositsResponse, cosmwasm_std::StdError> {
+        QueryDepositsRequest {
+            proposal_id,
+            pagination,
+        }
+        .query(self.querier)
+    }
+    pub fn tally_result(
+        &self,
+        proposal_id: u64,
+    ) -> Result<QueryTallyResultResponse, cosmwasm_std::StdError> {
+        QueryTallyResultRequest { proposal_id }.query(self.querier)
+    }
+}

--- a/packages/osmosis-std/src/types/cosmos/mod.rs
+++ b/packages/osmosis-std/src/types/cosmos/mod.rs
@@ -2,4 +2,5 @@ pub mod auth;
 pub mod authz;
 pub mod bank;
 pub mod base;
+pub mod gov;
 pub mod staking;

--- a/packages/proto-build/src/main.rs
+++ b/packages/proto-build/src/main.rs
@@ -66,6 +66,7 @@ pub fn generate() {
             "authz".to_string(),
             "bank".to_string(),
             "base".to_string(),
+            "gov".to_string(),
             "staking/v1beta1/genesis.proto".to_string(),
             "staking/v1beta1/staking.proto".to_string(),
             "staking/v1beta1/tx.proto".to_string(),

--- a/tests/osmosis-std-cosmwasm-test/Cargo.toml
+++ b/tests/osmosis-std-cosmwasm-test/Cargo.toml
@@ -47,7 +47,6 @@ cw-storage-plus = "0.15"
 cw2 = "0.13.2"
 jsonformat = "2.0.0"
 osmosis-std = {path = "../../packages/osmosis-std"}
-osmosis-test-tube = "15.1.0"
 schemars = "0.8.8"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 thiserror = {version = "1.0.31"}
@@ -56,3 +55,4 @@ thiserror = {version = "1.0.31"}
 cw-multi-test = "0.13.2"
 prost = "0.11.0"
 serde_json = "1.0.85"
+osmosis-test-tube = "15.1.0"

--- a/tests/osmosis-std-cosmwasm-test/Cargo.toml
+++ b/tests/osmosis-std-cosmwasm-test/Cargo.toml
@@ -47,7 +47,7 @@ cw-storage-plus = "0.15"
 cw2 = "0.13.2"
 jsonformat = "2.0.0"
 osmosis-std = {path = "../../packages/osmosis-std"}
-osmosis-test-tube = "14.1.1"
+osmosis-test-tube = "15.1.0"
 schemars = "0.8.8"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 thiserror = {version = "1.0.31"}


### PR DESCRIPTION
cosmwasm-std has a feature `backtraces` that lets you see which line number an Error came from. This is very useful as otherwise in tests you just get the test line number where you do .unwrap. Unfortunately osmosis-std currently breaks if you try to enable the `backtraces` feature since `osmosis-std-derive` tries to create `StdError` without the `backtrace` parameter. This PR fixes that. It also fixes some other bugs where the tests did not compile (the tests still fail, but this is also from upstream main, I did not bother to fix them). Lastly it generates types for the Cosmos gov module so that we can use them in `osmosis-test-tube` instead of relying on `cosmrs`.