### PR TITLE
fix: Use StdError constructor functions

### DIFF
--- a/packages/osmosis-std/README.md
+++ b/packages/osmosis-std/README.md
@@ -85,14 +85,12 @@ fn query_pool(
 ) -> StdResult<osmosis_std::types::osmosis::gamm::v1beta1::Pool> {
     let res = GammQuerier::new(&deps.querier).pool(pool_id)?;
     res.pool
-        .ok_or_else(|| StdError::NotFound {
-            kind: "pool".to_string(),
-        })?
+        .ok_or_else(|| StdError::not_found("pool"))?
         .try_into() // convert `Any` to `osmosis_std::types::osmosis::gamm::v1beta1::Pool`
-        .map_err(|e: DecodeError| StdError::ParseErr {
-            target_type: "osmosis_std::types::osmosis::gamm::v1beta1::Pool".to_string(),
-            msg: e.to_string(),
-        })
+        .map_err(|e: DecodeError| StdError::parse_err(
+            "osmosis_std::types::osmosis::gamm::v1beta1::Pool",
+            e
+        ))
 }
 ```
 
@@ -119,10 +117,10 @@ impl TryFrom<osmosis_std::shim::Any> for Pool {
             return Ok(Pool::StableSwap(pool));
         }
 
-        Err(StdError::ParseErr {
-            target_type: "Pool".to_string(),
-            msg: "Unmatched pool: must be either `Balancer` or `StableSwap`.".to_string(),
-        })
+        Err(StdError::parse_err(
+            "Pool",
+            "Unmatched pool: must be either `Balancer` or `StableSwap`."
+        ))
     }
 }
 
@@ -132,9 +130,7 @@ fn query_pool(
 ) -> StdResult<Pool> {
     let res = GammQuerier::new(&deps.querier).pool(pool_id)?;
     res.pool
-        .ok_or_else(|| StdError::NotFound {
-            kind: "pool".to_string(),
-        })?
+        .ok_or_else(|| StdError::not_found("pool"))?
         .try_into() // convert `Any` to `Pool`
 }
 ```


### PR DESCRIPTION
After discussing here: https://github.com/CosmWasm/cosmwasm/issues/1760#issuecomment-1620192501
@webmaster128 mentioned that it makes more sense to use the constructor functions for StdError. This way we don't have to add the backtraces field and also don't need a backtraces feature for osmosis-std. I didn't yet remove the backtraces feature though since that would be a breaking change. We can do it in the next major version.