### PR TITLE
fix json deserialization into stableswap pool type

### DIFF
--- a/packages/osmosis-std/src/serde/mod.rs
+++ b/packages/osmosis-std/src/serde/mod.rs
@@ -20,3 +20,30 @@ pub mod as_str {
         serializer.serialize_str(&value.to_string())
     }
 }
+
+pub mod as_str_vec {
+    use serde::{de, Deserialize, Deserializer, Serializer, Serialize};
+    use std::{fmt::Display, str::FromStr};
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        T: FromStr,
+        T::Err: Display,
+        D: Deserializer<'de>,
+    {
+        let vec_of_strings: Vec<String> = Vec::deserialize(deserializer)?;
+        vec_of_strings
+            .into_iter()
+            .map(|s| T::from_str(&s).map_err(de::Error::custom))
+            .collect()
+    }
+
+    pub fn serialize<S, T>(values: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Display,
+    {
+        let vec_of_strings: Vec<String> = values.iter().map(|value| value.to_string()).collect();
+        vec_of_strings.serialize(serializer)
+    }
+}

--- a/packages/osmosis-std/src/types/osmosis/gamm/poolmodels/stableswap/v1beta1.rs
+++ b/packages/osmosis-std/src/types/osmosis/gamm/poolmodels/stableswap/v1beta1.rs
@@ -69,6 +69,10 @@ pub struct Pool {
         ::prost::alloc::vec::Vec<super::super::super::super::super::cosmos::base::v1beta1::Coin>,
     /// for calculation amognst assets with different precisions
     #[prost(uint64, repeated, packed = "false", tag = "7")]
+    #[serde(
+        serialize_with = "crate::serde::as_str_vec::serialize",
+        deserialize_with = "crate::serde::as_str_vec::deserialize"
+    )]
     pub scaling_factors: ::prost::alloc::vec::Vec<u64>,
     /// scaling_factor_controller is the address can adjust pool scaling factors
     #[prost(string, tag = "8")]

--- a/packages/proto-build/src/transform.rs
+++ b/packages/proto-build/src/transform.rs
@@ -161,7 +161,8 @@ fn transform_items(
                 let s = transformers::add_derive_eq_struct(&s);
                 let s = transformers::append_attrs_struct(src, &s, descriptor);
                 let s = transformers::serde_alias_id_with_uppercased(s);
-                transformers::allow_serde_int_as_str(s)
+                let s = transformers::allow_serde_int_as_str(s);
+                transformers::allow_serde_vec_int_as_vec_str(s)
             }),
 
             Item::Enum(e) => Item::Enum({


### PR DESCRIPTION
## Context
The stableswap pool type has a scaling factor attribute of type `Vec<u64>`; however, the json schema defines the same field as an array of Strings. As a result, when querying this pool, the deserialization fails. This PR adds a custom serializer/deserializer to safely convert the `Vec<String>` type from the query response into the preferred `Vec<u64>` type. 

## Brief Changelog
* Added `as_str_vec` serializers and deserializers
* Added the functions as annotations to the scaling factor attribute

## Code to reproduce the error
```rust
use osmosis_std::types::osmosis::gamm::poolmodels::stableswap::v1beta1::Pool as StableswapPool;
use osmosis_std::types::osmosis::poolmanager::v1beta1::PoolmanagerQuerier;

let query_pool_resp = PoolmanagerQuerier::new(&deps.querier).pool(pool_id)?;
let stableswap_pool: StableswapPool = query_pool_resp
    .pool
    .ok_or(ContractError::PoolNotFoundOsmosis { pool_id })?
    .try_into()
    .map_err(|e| {
        StdError::parse_err(
            "osmosis_std::types::osmosis::gamm::poolmodels::stableswap::v1beta1::Pool",
            e,
        )
    })?;
```

## Error message before fix
```
Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: Error parsing into type osmosis_std::types::osmosis::poolmanager::v1beta1::PoolResponse: Invalid type string "100000". Expected u64: execute wasm contract failed: invalid request
```