### PR TITLE
[Fix] Bump chrono to 0.4.27

### DIFF
--- a/packages/osmosis-std/Cargo.toml
+++ b/packages/osmosis-std/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.19.1"
 backtraces = ["cosmwasm-std/backtraces", "osmosis-std-derive/backtraces"]
 
 [dependencies]
-chrono = {version = "0.4.22", default-features = false}
+chrono = {version = "0.4.27", default-features = false}
 cosmwasm-std = {version = "1.4.0", features = ["stargate"]}
 osmosis-std-derive = {version = "0.16.2", path = "../osmosis-std-derive"}
 prost = {version = "0.11.0", default-features = false, features = ["prost-derive"]}


### PR DESCRIPTION
Bumps chrono dependency of `osmosis-std` to `v0.4.27` because `>=v0.4.27` is incompatible with lower versions, causing our builds to fail:

```
error[E0599]: no function or associated item named `from_naive_utc_and_offset` found for struct `DateTime` in the current scope
  --> packages/osmosis-std/src/shim.rs:39:43
   |
39 |         let dt: DateTime<Utc> = DateTime::from_naive_utc_and_offset(dt, Utc);
   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `DateTime<_>`
   ```