### PR TITLE
fix: fix warning about `resolver`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["packages/*", "tests/*"]

--- a/packages/proto-build/Cargo.toml
+++ b/packages/proto-build/Cargo.toml
@@ -17,7 +17,7 @@ prost-build = "0.10"
 prost-types = "0.10"
 quote = "1.0.26"
 regex = "1"
-syn = {version = "1.0.98", features = ["full", "parsing"]}
+syn = {version = "1.0.98", features = ["full", "parsing", "extra-traits"]}
 tonic = "0.7"
 tonic-build = "0.7"
 walkdir = "2"


### PR DESCRIPTION
This pr fix this warning.
"warning: virtual workspace defaulting to `resolver = "1"` despite
 one or more workspace members being on edition 2021 which implies `resolver = "2"`"

By specifying resolver = "2", it is now necessary to specify `extra-traits` in the syn crate of `dependencies` in packages/osmosis-std.

## refs
>Available on crate feature extra-traits only.
https://docs.rs/syn/latest/syn/enum.Type.html#impl-PartialEq-for-Type