### PR TITLE
Prevent adding unused import "osmosis_std_derive::CosmwasmExt"

### DIFF
--- a/packages/proto-build/src/transform.rs
+++ b/packages/proto-build/src/transform.rs
@@ -100,7 +100,6 @@ fn transform_module(
     nested_mod: bool,
 ) -> Vec<Item> {
     let items = transform_items(items, src, ancestors, descriptor);
-    let items = prepend(items);
 
     append(items, src, descriptor, nested_mod)
 }
@@ -131,7 +130,7 @@ fn transform_items(
     ancestors: &[String],
     descriptor: &FileDescriptorSet,
 ) -> Vec<Item> {
-    items
+    let items = items
         .into_iter()
         .map(|i| match i {
             Item::Struct(s) => Item::Struct({
@@ -155,7 +154,16 @@ fn transform_items(
             i => i,
         })
         .map(|i: Item| transform_nested_mod(i, src, ancestors, descriptor))
-        .collect::<Vec<Item>>()
+        .collect::<Vec<Item>>();
+
+    if items.clone().into_iter().any(|i| match i {
+        Item::Struct(_) => true,
+        _ => false,
+    }) {
+        prepend(items)
+    } else {
+        items
+    }
 }
 
 fn transform_nested_mod(


### PR DESCRIPTION
Without this PR, transform adds `import osmosis_std_derive::CosmwasmExt` to all modules given to `transform_module`.
This PR prevents adding `import osmosis_std_derive::CosmwasmExt` modules not using it.
Modules that do not use `import osmosis_std_derive::CosmwasmExt` contain only enums and do not contain structs.