### PR TITLE
Add NoLockTime to doc comments for QueryCondition

### DIFF
--- a/packages/osmosis-std/src/types/osmosis/lockup.rs
+++ b/packages/osmosis-std/src/types/osmosis/lockup.rs
@@ -65,7 +65,7 @@ pub struct PeriodLock {
 )]
 #[proto_message(type_url = "/osmosis.lockup.QueryCondition")]
 pub struct QueryCondition {
-    /// LockQueryType is a type of lock query, ByLockDuration | ByLockTime
+    /// LockQueryType is a type of lock query, ByLockDuration | ByLockTime | NoLockTime
     #[prost(enumeration = "LockQueryType", tag = "1")]
     #[serde(
         serialize_with = "crate::serde::as_str::serialize",


### PR DESCRIPTION
It took a little longer to find that 2 = NoLockTime if going based on the comments above the param lock_query_time, so I added it 