### PR TITLE
 Fix deserialisation error on `next_key`

### DIFF
--- a/packages/osmosis-std/src/types/cosmos/base/query/v1beta1.rs
+++ b/packages/osmosis-std/src/types/cosmos/base/query/v1beta1.rs
@@ -80,12 +80,8 @@ pub struct PageResponse {
     /// next_key is the key to be passed to PageRequest.key to
     /// query the next page most efficiently. It will be empty if
     /// there are no more results.
-    #[prost(bytes = "vec", tag = "1")]
-    #[serde(
-        serialize_with = "crate::serde::as_base64_encoded_string::serialize",
-        deserialize_with = "crate::serde::as_base64_encoded_string::deserialize"
-    )]
-    pub next_key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub next_key: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     /// total is total number of results available if PageRequest.count_total
     /// was set, its value is undefined otherwise
     #[prost(uint64, tag = "2")]

--- a/packages/osmosis-std/src/types/cosmos/base/query/v1beta1.rs
+++ b/packages/osmosis-std/src/types/cosmos/base/query/v1beta1.rs
@@ -81,6 +81,10 @@ pub struct PageResponse {
     /// query the next page most efficiently. It will be empty if
     /// there are no more results.
     #[prost(bytes = "vec", optional, tag = "1")]
+    #[serde(
+        serialize_with = "crate::serde::as_base64_encoded_string::serialize",
+        deserialize_with = "crate::serde::as_base64_encoded_string::deserialize"
+    )]
     pub next_key: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     /// total is total number of results available if PageRequest.count_total
     /// was set, its value is undefined otherwise

--- a/packages/proto-build/src/transform.rs
+++ b/packages/proto-build/src/transform.rs
@@ -138,6 +138,7 @@ fn transform_items(
                 let s = transformers::add_derive_eq_struct(&s);
                 let s = transformers::append_attrs_struct(src, &s, descriptor);
                 let s = transformers::serde_alias_id_with_uppercased(s);
+                let s = transformers::make_next_key_optional(s);
                 let s = transformers::allow_serde_vec_u8_as_base64_encoded_string(s);
                 let s = transformers::allow_serde_int_as_str(s);
 

--- a/packages/proto-build/src/transform.rs
+++ b/packages/proto-build/src/transform.rs
@@ -138,8 +138,8 @@ fn transform_items(
                 let s = transformers::add_derive_eq_struct(&s);
                 let s = transformers::append_attrs_struct(src, &s, descriptor);
                 let s = transformers::serde_alias_id_with_uppercased(s);
-                let s = transformers::make_next_key_optional(s);
                 let s = transformers::allow_serde_vec_u8_as_base64_encoded_string(s);
+                let s = transformers::make_next_key_optional(s);
                 let s = transformers::allow_serde_int_as_str(s);
 
                 transformers::allow_serde_vec_int_as_vec_str(s)

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -757,6 +757,10 @@ mod tests {
         let input: ItemStruct = parse_quote! {
             pub struct PageResponse {
                 #[prost(bytes = "vec", tag = "1")]
+                #[serde(
+                    serialize_with = "crate::serde::as_base64_encoded_string::serialize",
+                    deserialize_with = "crate::serde::as_base64_encoded_string::deserialize"
+                )]
                 pub next_key: ::prost::alloc::vec::Vec<u8>,
             }
         };
@@ -766,6 +770,10 @@ mod tests {
         let expected: ItemStruct = parse_quote! {
             pub struct PageResponse {
                 #[prost(bytes = "vec", optional, tag = "1")]
+                #[serde(
+                    serialize_with = "crate::serde::as_base64_encoded_string::serialize",
+                    deserialize_with = "crate::serde::as_base64_encoded_string::deserialize"
+                )]
                 pub next_key: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
             }
         };

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -303,6 +303,31 @@ pub fn serde_alias_id_with_uppercased(s: ItemStruct) -> ItemStruct {
 
     syn::ItemStruct { fields, ..s }
 }
+
+pub fn make_next_key_optional(mut s: ItemStruct) -> ItemStruct {
+    if s.ident == "PageResponse" {
+        if let Fields::Named(ref mut fields_named) = s.fields {
+            for field in fields_named.named.iter_mut() {
+                if let Some(ident) = &field.ident {
+                    if ident == "next_key" {
+                        field.ty =
+                            parse_quote!(::core::option::Option<::prost::alloc::vec::Vec<u8>>);
+                        for attr in field.attrs.iter_mut() {
+                            if attr.path.is_ident("prost") {
+                                *attr = parse_quote! {
+                                    #[prost(bytes = "vec", optional, tag = "1")]
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    s
+}
+
 // ====== helpers ======
 
 fn get_query_attr(
@@ -721,6 +746,27 @@ mod tests {
                 pub denom: ::prost::alloc::string::String,
                 #[serde(alias = "poolID")]
                 pub pool_id: u64,
+            }
+        };
+
+        assert_ast_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_make_next_key_optional() {
+        let input: ItemStruct = parse_quote! {
+            pub struct PageResponse {
+                #[prost(bytes = "vec", tag = "1")]
+                pub next_key: ::prost::alloc::vec::Vec<u8>,
+            }
+        };
+
+        let result = make_next_key_optional(input);
+
+        let expected: ItemStruct = parse_quote! {
+            pub struct PageResponse {
+                #[prost(bytes = "vec", optional, tag = "1")]
+                pub next_key: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
             }
         };
 


### PR DESCRIPTION
For queries that return paginated responses the next key value can be
null

```json
{"positions":[],"pagination":{"next_key":null,"total":"0"}}
```

This leads to a deserialisation error. This fixes the issue by making
next_key optional.

The issue was first reported by @keyleu with a fix so due credit here.

https://github.com/osmosis-labs/osmosis-rust/issues/104
