### PR TITLE
    Fix serialization/deserialization for Option

### DIFF
--- a/packages/osmosis-std/src/serde/mod.rs
+++ b/packages/osmosis-std/src/serde/mod.rs
@@ -69,3 +69,34 @@ pub mod as_base64_encoded_string {
         Binary(values.to_vec()).to_base64().serialize(serializer)
     }
 }
+
+pub mod as_option_base64_encoded_string {
+    use cosmwasm_std::Binary;
+    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded_string: Option<String> = Option::deserialize(deserializer)?;
+        match encoded_string {
+            Some(s) => Binary::from_base64(&s)
+                .map(|b| Some(b.to_vec()))
+                .map_err(de::Error::custom),
+            None => Ok(None),
+        }
+    }
+
+    pub fn serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(vec) => {
+                let encoded_string = Binary(vec.clone()).to_base64();
+                encoded_string.serialize(serializer)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+}

--- a/packages/osmosis-std/src/types/cosmos/base/query/v1beta1.rs
+++ b/packages/osmosis-std/src/types/cosmos/base/query/v1beta1.rs
@@ -82,8 +82,8 @@ pub struct PageResponse {
     /// there are no more results.
     #[prost(bytes = "vec", optional, tag = "1")]
     #[serde(
-        serialize_with = "crate::serde::as_base64_encoded_string::serialize",
-        deserialize_with = "crate::serde::as_base64_encoded_string::deserialize"
+        serialize_with = "crate::serde::as_option_base64_encoded_string::serialize",
+        deserialize_with = "crate::serde::as_option_base64_encoded_string::deserialize"
     )]
     pub next_key: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     /// total is total number of results available if PageRequest.count_total

--- a/packages/proto-build/src/transform.rs
+++ b/packages/proto-build/src/transform.rs
@@ -138,8 +138,9 @@ fn transform_items(
                 let s = transformers::add_derive_eq_struct(&s);
                 let s = transformers::append_attrs_struct(src, &s, descriptor);
                 let s = transformers::serde_alias_id_with_uppercased(s);
-                let s = transformers::allow_serde_vec_u8_as_base64_encoded_string(s);
                 let s = transformers::make_next_key_optional(s);
+                let s = transformers::allow_serde_option_vec_u8_as_base64_encoded_string(s);
+                let s = transformers::allow_serde_vec_u8_as_base64_encoded_string(s);
                 let s = transformers::allow_serde_int_as_str(s);
 
                 transformers::allow_serde_vec_int_as_vec_str(s)

--- a/packages/proto-build/src/transform.rs
+++ b/packages/proto-build/src/transform.rs
@@ -138,7 +138,6 @@ fn transform_items(
                 let s = transformers::add_derive_eq_struct(&s);
                 let s = transformers::append_attrs_struct(src, &s, descriptor);
                 let s = transformers::serde_alias_id_with_uppercased(s);
-                let s = transformers::allow_serde_vec_u8_as_base64_encoded_string(s);
                 // A hack to make Pagination::next_key optional.
                 // Remove if [this PR](https://github.com/cosmos/cosmos-sdk/pull/20246) is merged and released
                 let s = transformers::make_next_key_optional(s);


### PR DESCRIPTION
The previous implementation threw a type error.

|     ::serde::Serialize,
|     ^^^^^^^^^^^^^^^^^^ expected `&[u8]`, found `&Option<Vec<u8>>`

This adds custom serde functions and an additional transformer to
handle the option correctly.

  

