### PR TITLE
Cosmwasm 2.0 bump

### DIFF
--- a/examples/cosmwasm/contracts/osmosis-stargate/Cargo.toml
+++ b/examples/cosmwasm/contracts/osmosis-stargate/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Supanat Potiwarakorn <supanat.ptk@gmail.com>"]
 edition = "2018"
 name = "osmosis-stargate"
-version = "0.1.0"
+version = "0.2.0"
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -27,8 +27,6 @@ panic = 'abort'
 rpath = false
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
@@ -40,17 +38,16 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = {version = "1.0.0", features = ["stargate"]}
-cosmwasm-storage = "1.0.0"
-cw-storage-plus = "0.13.2"
-cw2 = "0.13.2"
+cosmwasm-std = { version = "2.0.0", features = ["stargate"] }
+cw-storage-plus = "2.0.0"
+cw2 = "2.0.0"
 osmo-bindings = "0.5.1"
-osmosis-std = {path = "../../../../packages/osmosis-std"}
+osmosis-std = { path = "../../../../packages/osmosis-std" }
 prost = "0.10.4"
 schemars = "0.8.8"
-serde = {version = "1.0.137", default-features = false, features = ["derive"]}
-thiserror = {version = "1.0.31"}
+serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.31" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
-cw-multi-test = "0.13.2"
+cosmwasm-schema = "2.0.0"
+cw-multi-test = "2.0.0"

--- a/packages/osmosis-std-derive/Cargo.toml
+++ b/packages/osmosis-std-derive/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.20.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-backtraces = ["cosmwasm-std/backtraces"]
 
 [lib]
 proc-macro = true
@@ -21,7 +20,7 @@ quote = "1.0.20"
 syn = "1.0.98"
 
 [dev-dependencies]
-cosmwasm-std = {version = "1.1.2", features = ["stargate"]}
+cosmwasm-std = { version = "2.0.0", features = ["stargate"] }
 prost = "0.11"
 serde = "1.0.142"
-trybuild = {version = "1.0.63", features = ["diff"]}
+trybuild = { version = "1.0.63", features = ["diff"] }

--- a/packages/osmosis-std-derive/src/lib.rs
+++ b/packages/osmosis-std-derive/src/lib.rs
@@ -84,7 +84,7 @@ pub fn derive_cosmwasm_ext(input: TokenStream) -> TokenStream {
 
         impl From<#ident> for cosmwasm_std::Binary {
             fn from(msg: #ident) -> Self {
-                cosmwasm_std::Binary(msg.to_proto_bytes())
+                cosmwasm_std::Binary::new(msg.to_proto_bytes())
             }
         }
 

--- a/packages/osmosis-std/Cargo.toml
+++ b/packages/osmosis-std/Cargo.toml
@@ -9,16 +9,17 @@ version = "0.25.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-backtraces = ["cosmwasm-std/backtraces", "osmosis-std-derive/backtraces"]
 
 [dependencies]
-chrono = {version = "0.4.27", default-features = false}
-cosmwasm-std = {version = "1.4.0", features = ["stargate"]}
-osmosis-std-derive = {version = "0.20.1", path = "../osmosis-std-derive"}
-prost = {version = "0.12.3", default-features = false, features = ["prost-derive"]}
-prost-types = {version = "0.12.3", default-features = false}
+chrono = { version = "0.4.27", default-features = false }
+cosmwasm-std = { version = "2.0.0", features = ["stargate"] }
+osmosis-std-derive = { version = "0.20.1", path = "../osmosis-std-derive" }
+prost = { version = "0.12.3", default-features = false, features = [
+    "prost-derive",
+] }
+prost-types = { version = "0.12.3", default-features = false }
 schemars = "0.8.8"
 
 # for query
-serde = {version = "1.0", default-features = false, features = ["derive"]}
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-cw-value = "0.7.0"

--- a/packages/osmosis-std/src/serde/mod.rs
+++ b/packages/osmosis-std/src/serde/mod.rs
@@ -66,7 +66,9 @@ pub mod as_base64_encoded_string {
     where
         S: Serializer,
     {
-        Binary(values.to_vec()).to_base64().serialize(serializer)
+        Binary::new(values.to_vec())
+            .to_base64()
+            .serialize(serializer)
     }
 }
 
@@ -93,7 +95,7 @@ pub mod as_option_base64_encoded_string {
     {
         match value {
             Some(vec) => {
-                let encoded_string = Binary(vec.clone()).to_base64();
+                let encoded_string = Binary::new(vec.clone()).to_base64();
                 encoded_string.serialize(serializer)
             }
             None => serializer.serialize_none(),

--- a/packages/proto-build/Cargo.toml
+++ b/packages/proto-build/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Supanat Potiwarakorn <boss@osmosis.team>", "Justin Kilpatrick <justin@althea.net>", "Tony Arcieri <tony@iqlusion.io>"]
+authors = [
+    "Supanat Potiwarakorn <boss@osmosis.team>",
+    "Justin Kilpatrick <justin@althea.net>",
+    "Tony Arcieri <tony@iqlusion.io>",
+]
 edition = "2021"
 name = "proto-build"
 publish = false
@@ -17,7 +21,7 @@ prost-build = "0.10"
 prost-types = "0.10"
 quote = "1.0.26"
 regex = "1"
-syn = {version = "1.0.98", features = ["full", "parsing", "extra-traits"]}
+syn = { version = "1.0.98", features = ["full", "parsing", "extra-traits"] }
 tonic = "0.7"
 tonic-build = "0.7"
 walkdir = "2"

--- a/tests/osmosis-std-cosmwasm-test/Cargo.toml
+++ b/tests/osmosis-std-cosmwasm-test/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Supanat Potiwarakorn <supanat.ptk@gmail.com>"]
 edition = "2021"
 name = "osmosis-std-cosmwasm-test"
-version = "0.1.0"
+version = "0.2.0"
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -27,8 +27,6 @@ panic = 'abort'
 rpath = false
 
 [features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
@@ -40,19 +38,18 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-schema = "1.1.2"
-cosmwasm-std = "1.1.2"
-cosmwasm-storage = "1.1.2"
-cw-storage-plus = "0.15"
-cw2 = "0.13.2"
+cosmwasm-schema = "2.0.0"
+cosmwasm-std = "2.0.0"
+cw-storage-plus = "2.0.0"
+cw2 = "2.0.0"
 jsonformat = "2.0.0"
-osmosis-std = {path = "../../packages/osmosis-std"}
+osmosis-std = { path = "../../packages/osmosis-std" }
 schemars = "0.8.8"
-serde = {version = "1.0.137", default-features = false, features = ["derive"]}
-thiserror = {version = "1.0.31"}
+serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.31" }
 
 [dev-dependencies]
-cw-multi-test = "0.13.2"
+cw-multi-test = "2.0.0"
 prost = "0.11.0"
 serde_json = "1.0.85"
 osmosis-test-tube = "20.1.1"


### PR DESCRIPTION
Closes #114
`osmosis-std-cosmwasm-test` tests now doesn't compile because test tube is not upgraded to cosmwasm 2.0. But I guess osmosis-std should be bumped first